### PR TITLE
Fix Trainlines (#177)

### DIFF
--- a/mapobjectdb/postgres/mapobjects.go
+++ b/mapobjectdb/postgres/mapobjects.go
@@ -19,13 +19,22 @@ func (db *PostgresAccessor) GetMapData(q *mapobjectdb.SearchQuery) ([]*mapobject
 	}
 
 	if q.AttributeLike == nil {
-		//plain pos search
-		rows, err = db.db.Query(getMapDataPosQuery,
-			q.Type,
-			q.Pos1.X, q.Pos1.Y, q.Pos1.Z,
-			q.Pos2.X, q.Pos2.Y, q.Pos2.Z,
-			limit,
-		)
+		if (q.Pos1 == nil || q.Pos2 == nil) {
+			//global attribute like search
+			rows, err = db.db.Query(getMapDataWithAttributeLikeGlobalQuery,
+				q.AttributeLike.Key, q.AttributeLike.Value,
+				q.Type,
+				limit,
+			)
+		} else {
+			//plain pos search
+			rows, err = db.db.Query(getMapDataPosQuery,
+				q.Type,
+				q.Pos1.X, q.Pos1.Y, q.Pos1.Z,
+				q.Pos2.X, q.Pos2.Y, q.Pos2.Z,
+				limit,
+			)
+		}
 
 	} else {
 		//attribute like search

--- a/mapobjectdb/postgres/mapobjects.go
+++ b/mapobjectdb/postgres/mapobjects.go
@@ -19,6 +19,15 @@ func (db *PostgresAccessor) GetMapData(q *mapobjectdb.SearchQuery) ([]*mapobject
 	}
 
 	if q.AttributeLike == nil {
+		//plain pos search
+		rows, err = db.db.Query(getMapDataPosQuery,
+			q.Type,
+			q.Pos1.X, q.Pos1.Y, q.Pos1.Z,
+			q.Pos2.X, q.Pos2.Y, q.Pos2.Z,
+			limit,
+		)
+
+	} else {
 		if (q.Pos1 == nil || q.Pos2 == nil) {
 			//global attribute like search
 			rows, err = db.db.Query(getMapDataWithAttributeLikeGlobalQuery,
@@ -27,24 +36,15 @@ func (db *PostgresAccessor) GetMapData(q *mapobjectdb.SearchQuery) ([]*mapobject
 				limit,
 			)
 		} else {
-			//plain pos search
-			rows, err = db.db.Query(getMapDataPosQuery,
+			//attribute like search
+			rows, err = db.db.Query(getMapDataWithAttributeLikePosQuery,
 				q.Type,
 				q.Pos1.X, q.Pos1.Y, q.Pos1.Z,
 				q.Pos2.X, q.Pos2.Y, q.Pos2.Z,
+				q.AttributeLike.Key, q.AttributeLike.Value,
 				limit,
 			)
 		}
-
-	} else {
-		//attribute like search
-		rows, err = db.db.Query(getMapDataWithAttributeLikePosQuery,
-			q.Type,
-			q.Pos1.X, q.Pos1.Y, q.Pos1.Z,
-			q.Pos2.X, q.Pos2.Y, q.Pos2.Z,
-			q.AttributeLike.Key, q.AttributeLike.Value,
-			limit,
-		)
 	}
 
 	if err != nil {

--- a/mapobjectdb/postgres/sql.go
+++ b/mapobjectdb/postgres/sql.go
@@ -29,6 +29,20 @@ and o.posx <= $5 and o.posy <= $6 and o.posz <= $7
 order by o.id
 limit $10
 `
+const getMapDataWithAttributeLikeGlobalQuery = `
+select o.id, o.type, o.mtime,
+ o.x, o.y, o.z,
+ o.posx, o.posy, o.posz,
+ oa.key, oa.value
+from objects o
+left join object_attributes oa on o.id = oa.objectid
+where o.id in (
+  select objectid from object_attributes where key = $2 and value ilike $3
+)
+and o.type = $1
+order by o.id
+limit $4
+`
 
 const removeMapDataQuery = `
 delete from objects where posx = $1 and posy = $2 and posz = $3

--- a/mapobjectdb/sqlite/mapobjects.go
+++ b/mapobjectdb/sqlite/mapobjects.go
@@ -19,6 +19,15 @@ func (db *Sqlite3Accessor) GetMapData(q *mapobjectdb.SearchQuery) ([]*mapobjectd
 	}
 
 	if q.AttributeLike == nil {
+		//plain pos search
+		rows, err = db.db.Query(getMapDataPosQuery,
+			q.Type,
+			q.Pos1.X, q.Pos1.Y, q.Pos1.Z,
+			q.Pos2.X, q.Pos2.Y, q.Pos2.Z,
+			limit,
+		)
+
+	} else {
 		if (q.Pos1 == nil || q.Pos2 == nil) {
 			//global attribute like search
 			rows, err = db.db.Query(getMapDataWithAttributeLikeGlobalQuery,
@@ -27,24 +36,15 @@ func (db *Sqlite3Accessor) GetMapData(q *mapobjectdb.SearchQuery) ([]*mapobjectd
 				limit,
 			)
 		} else {
-			//plain pos search
-			rows, err = db.db.Query(getMapDataPosQuery,
+			//attribute like search
+			rows, err = db.db.Query(getMapDataWithAttributeLikePosQuery,
+				q.AttributeLike.Key, q.AttributeLike.Value,
 				q.Type,
 				q.Pos1.X, q.Pos1.Y, q.Pos1.Z,
 				q.Pos2.X, q.Pos2.Y, q.Pos2.Z,
 				limit,
 			)
 		}
-
-	} else {
-		//attribute like search
-		rows, err = db.db.Query(getMapDataWithAttributeLikePosQuery,
-			q.AttributeLike.Key, q.AttributeLike.Value,
-			q.Type,
-			q.Pos1.X, q.Pos1.Y, q.Pos1.Z,
-			q.Pos2.X, q.Pos2.Y, q.Pos2.Z,
-			limit,
-		)
 	}
 
 	if err != nil {

--- a/mapobjectdb/sqlite/mapobjects.go
+++ b/mapobjectdb/sqlite/mapobjects.go
@@ -19,13 +19,22 @@ func (db *Sqlite3Accessor) GetMapData(q *mapobjectdb.SearchQuery) ([]*mapobjectd
 	}
 
 	if q.AttributeLike == nil {
-		//plain pos search
-		rows, err = db.db.Query(getMapDataPosQuery,
-			q.Type,
-			q.Pos1.X, q.Pos1.Y, q.Pos1.Z,
-			q.Pos2.X, q.Pos2.Y, q.Pos2.Z,
-			limit,
-		)
+		if (q.Pos1 == nil || q.Pos2 == nil) {
+			//global attribute like search
+			rows, err = db.db.Query(getMapDataWithAttributeLikeGlobalQuery,
+				q.AttributeLike.Key, q.AttributeLike.Value,
+				q.Type,
+				limit,
+			)
+		} else {
+			//plain pos search
+			rows, err = db.db.Query(getMapDataPosQuery,
+				q.Type,
+				q.Pos1.X, q.Pos1.Y, q.Pos1.Z,
+				q.Pos2.X, q.Pos2.Y, q.Pos2.Z,
+				limit,
+			)
+		}
 
 	} else {
 		//attribute like search

--- a/mapobjectdb/sqlite/sql.go
+++ b/mapobjectdb/sqlite/sql.go
@@ -31,6 +31,21 @@ order by o.id
 limit ?
 `
 
+const getMapDataWithAttributeLikeGlobalQuery = `
+select o.id, o.type, o.mtime,
+ o.x, o.y, o.z,
+ o.posx, o.posy, o.posz,
+ oa.key, oa.value
+from objects o
+left join object_attributes oa on o.id = oa.objectid
+where o.id in (
+  select objectid from object_attributes where key = ? and value like ?
+)
+and o.type = ?
+order by o.id
+limit ?
+`
+
 const removeMapDataQuery = `
 delete from objects where posx = ? and posy = ? and posz = ?
 `

--- a/public/js/map/overlays/TrainlineOverlay.js
+++ b/public/js/map/overlays/TrainlineOverlay.js
@@ -14,41 +14,41 @@ export default AbstractGeoJsonOverlay.extend({
     // which unique lines do objects belong to?
     var lines = [];
     objects.forEach(function(obj){
-      if (obj.attributes.line && lines.indexOf(obj.attributes.line) > -1) {
+      if (obj.attributes.line && lines.indexOf(obj.attributes.line) == -1) {
         lines.push(obj.attributes.line);
       }
     });
     // query for each line, add to cache
     lines.forEach(function(l){
-      if (!this.cache[l]){
+      if (!self.cache[l]){
         // only request if not in cache.
         // if someone changed the train lines, the user has to reload. sorry.
-        this.pendingQueries.push(l);
+        self.pendingQueries.push(l);
         getMapObjects({
-          type: this.type,
+          type: self.type,
           attributelike: {
             key: "line",
             value: l
           }
         })
         .then(function(objects){
-          this.cache[l] = objects;
-          this.pendingQueries = this.pendingQueries.filter(function(e){
+          self.cache[l] = objects;
+          self.pendingQueries = self.pendingQueries.filter(function(e){
             return e != l;
           });
-          if (this.pendingQueries.length == 0) {
+          if (self.pendingQueries.length == 0) {
             // trigger a redraw
             // this will only happen if anything changed since it runs only after we completed a query
             self.clearLayers();
 
-            var geoJsonLayer = self.createGeoJsonInternal(this.cache);
+            var geoJsonLayer = self.createGeoJsonInternal(self.cache);
             geoJsonLayer.addTo(self);
           }
         });
       }
     });
     
-    return this.lastLayer;
+    return self.lastLayer;
   },
 
   createGeoJsonInternal: function(lines){

--- a/public/js/map/overlays/TrainlineOverlay.js
+++ b/public/js/map/overlays/TrainlineOverlay.js
@@ -4,56 +4,13 @@ import { getMapObjects } from '../../api.js';
 export default AbstractGeoJsonOverlay.extend({
   initialize: function() {
     AbstractGeoJsonOverlay.prototype.initialize.call(this, "train");
-    this.cache = {}; // { "A1":[] }
+    this.cache = {
+      lines: {}, // { "A1":[] }
+      lineColors: {}, // { "A1": "red" }
+      lineFeat: []
+    };
     this.pendingQueries = [];
-    this.lastLayer = L.geoJSON([], {}); // empty dummy, will be replaced later
-  },
-  
-  createGeoJson: function(objects){
-    var self = this;
-    // which unique lines do objects belong to?
-    var lines = [];
-    objects.forEach(function(obj){
-      if (obj.attributes.line && lines.indexOf(obj.attributes.line) == -1) {
-        lines.push(obj.attributes.line);
-      }
-    });
-    // query for each line, add to cache
-    lines.forEach(function(l){
-      if (!self.cache[l]){
-        // only request if not in cache.
-        // if someone changed the train lines, the user has to reload. sorry.
-        self.pendingQueries.push(l);
-        getMapObjects({
-          type: self.type,
-          attributelike: {
-            key: "line",
-            value: l
-          }
-        })
-        .then(function(objects){
-          self.cache[l] = objects;
-          self.pendingQueries = self.pendingQueries.filter(function(e){
-            return e != l;
-          });
-          if (self.pendingQueries.length == 0) {
-            // trigger a redraw
-            // this will only happen if anything changed since it runs only after we completed a query
-            self.clearLayers();
-
-            var geoJsonLayer = self.createGeoJsonInternal(self.cache);
-            geoJsonLayer.addTo(self);
-          }
-        });
-      }
-    });
-    
-    return self.lastLayer;
-  },
-
-  createGeoJsonInternal: function(lines){
-
-    var geoJsonLayer = L.geoJSON([], {
+    this.lastLayer = L.geoJSON([], {
       onEachFeature: function(feature, layer){
         if (feature.properties && feature.properties.popupContent) {
           layer.bindPopup(feature.properties.popupContent);
@@ -75,80 +32,101 @@ export default AbstractGeoJsonOverlay.extend({
         }
       }
     });
+  },
+  
+  createGeoJson: function(objects){
+    var self = this;
 
-    var lineColors = {}; // { "A1": "red" }
-
-    // already sorted, determine color
-    Object.keys(lines).forEach(function(linename){
-      if (!lineColors[linename]){
-        lineColors[linename] = "#ff7800";
-        for (var i = lines[linename].length-1; i >= 0; i--) {
-          // find the last element specifying a color
-          // as was previous behaviour, but be more efficient
-          if (lines[linename][i].attributes.color){
-            lineColors[linename] = lines[linename][i].attributes.color;
-            break;
-          }
-        }
+    // which unique lines do objects belong to?
+    var lines = [];
+    objects.forEach(function(obj){
+      if (obj.attributes.line && lines.indexOf(obj.attributes.line) == -1) {
+        lines.push(obj.attributes.line);
       }
     });
 
-    //Order by index and display
-    Object.keys(lines).forEach(function(linename){
-      lines[linename].sort(function(a,b){
-        return parseInt(a.attributes.index) - parseInt(b.attributes.index);
-      });
+    // query for each line, add to cache
+    lines.forEach(function(linename){
+      if (!self.cache.lines[linename]){
+        // only request if not in cache.
+        // if someone changed the train lines, the user has to reload. sorry.
+        self.pendingQueries.push(linename);
+        getMapObjects({
+          type: self.type,
+          attributelike: {
+            key: "line",
+            value: linename
+          }
+        })
+        .then(function(objects){
+          objects.sort(function(a,b){
+            return parseInt(a.attributes.index) - parseInt(b.attributes.index);
+          });
 
-      var coords = [];
-      var stations = [];
+          self.cache.lines[linename] = objects;
+          // already sorted, determine color
+          self.cache.lineColors[linename] = "#ff7800";
+          for (var i = objects.length-1; i >= 0; i--) {
+            // find the last element specifying a color
+            // as was previous behaviour, but be more efficient
+            if (objects[i].attributes.color){
+              self.cache.lineColors[linename] = objects[i].attributes.color;
+              break;
+            }
+          }
 
-      //Add stations
-      lines[linename].forEach(function(entry){
-        coords.push([entry.x, entry.z]);
+          var feat = {
+            coords: [],
+            stations: [],
+            feature: null
+          };
+          //Add stations
+          objects.forEach(function(entry){
+            feat.coords.push([entry.x, entry.z]);
 
-        if (entry.attributes.station) {
-          stations.push({
-            "type": "Feature",
-            "properties": {
-              "name": entry.attributes.station,
-              "color": lineColors[linename],
-              "popupContent": "<b>Train-station (Line " + entry.attributes.line + ")</b><hr>" +
-                entry.attributes.station
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [entry.x, entry.z]
+            if (entry.attributes.station) {
+              feat.stations.push({
+                "type": "Feature",
+                "properties": {
+                  "name": entry.attributes.station,
+                  "color": self.cache.lineColors[linename],
+                  "popupContent": "<b>Train-station (Line " + entry.attributes.line + ")</b><hr>" +
+                    entry.attributes.station
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [entry.x, entry.z]
+                }
+              });
             }
           });
-        }
-      });
 
-      var feature = {
-        "type":"Feature",
-        "geometry": {
-          "type":"LineString",
-          "coordinates":coords
-        },
-        "properties":{
-            "name": linename,
-            "color": lineColors[linename],
-            "popupContent": "<b>Train-line (" + linename + ")</b>"
-        }
-      };
+          feat.feature = {
+            "type":"Feature",
+            "geometry": {
+              "type":"LineString",
+              "coordinates": feat.coords
+            },
+            "properties":{
+                "name": linename,
+                "color": self.cache.lineColors[linename],
+                "popupContent": "<b>Train-line (" + linename + ")</b>"
+            }
+          };
 
-      //line-points
-      geoJsonLayer.addData(feature);
+          self.cache.lineFeat[linename] = feat;
 
-      //stations
-      stations.forEach(function(stationfeature){
-        geoJsonLayer.addData(stationfeature);
-      });
+          //line-points
+          self.lastLayer.addData(feat.feature);
 
-
+          //stations
+          feat.stations.forEach(function(stationfeature){
+            self.lastLayer.addData(stationfeature);
+          });
+        });
+      }
     });
 
-    this.lastLayer = geoJsonLayer;
-    return geoJsonLayer;
-  }
-
+    return self.lastLayer;
+  },
 });


### PR DESCRIPTION
This PR changes the way the trainlines overlay works and introduces a new mapobject query mode.

Instead of displaying all train objects in the viewport, those are only used as indicator which lines are visible. *All* markers for those lines are then queried (if not already in cache) and remembered. The lines get permanently added to the layer, it is never cleared. Should the data get modified by players, it won't be reflected in the map until the page is refreshed.

Behaviour with Postgres backend is still untested.