### PR TITLE
Add Natural Biomes colour mapping

### DIFF
--- a/app/setup.go
+++ b/app/setup.go
@@ -104,6 +104,7 @@ func Setup(p params.ParamsType, cfg *Config) *App {
 		"colors/miles.txt",
 		"colors/custom.txt",
 		"colors/nodecore.txt",
+		"colors/naturalbiomes.txt",
 	}
 
 	for _, colorfile := range colorfiles {

--- a/public/colors/naturalbiomes.txt
+++ b/public/colors/naturalbiomes.txt
@@ -1,0 +1,265 @@
+# crafting
+
+stairs:slab_naturalbiomes_adler_reed_bundle 94 76 57
+stairs:stair_naturalbiomes_adler_reed_bundle 94 76 57
+stairs:stair_outer_naturalbiomes_adler_reed_bundle 94 76 57
+stairs:stair_inner_naturalbiomes_adler_reed_bundle 94 76 57
+stairs:slab_naturalbiomes_alpine_rock_brick 150 157 165
+stairs:stair_naturalbiomes_alpine_rock_brick 150 157 165
+stairs:stair_outer_naturalbiomes_alpine_rock_brick 150 157 165
+stairs:stair_inner_naturalbiomes_alpine_rock_brick 150 157 165
+stairs:slab_naturalbiomes_bambooforest_rock_brick 143 106 76
+stairs:stair_naturalbiomes_bambooforest_rock_brick 143 106 76
+stairs:stair_outer_naturalbiomes_bambooforest_rock_brick 143 106 76
+stairs:stair_inner_naturalbiomes_bambooforest_rock_brick 143 106 76
+stairs:slab_naturalbiomes_beach_rock_brick 155 127 89
+stairs:stair_naturalbiomes_beach_rock_brick 155 127 89
+stairs:stair_outer_naturalbiomes_beach_rock_brick 155 127 89
+stairs:stair_inner_naturalbiomes_beach_rock_brick 155 127 89
+stairs:slab_naturalbiomes_mediterran_rock_brick 150 145 129
+stairs:stair_naturalbiomes_mediterran_rock_brick 150 145 129
+stairs:stair_outer_naturalbiomes_mediterran_rock_brick 150 145 129
+stairs:stair_inner_naturalbiomes_mediterran_rock_brick 150 145 129
+stairs:slab_naturalbiomes_outback_rock_brick 171 119 83
+stairs:stair_naturalbiomes_outback_rock_brick 171 119 83
+stairs:stair_outer_naturalbiomes_outback_rock_brick 171 119 83
+stairs:stair_inner_naturalbiomes_outback_rock_brick 171 119 83
+naturalbiomes:reed_bundle 150 157 165
+naturalbiomes:bamboo_brick 143 106 76
+naturalbiomes:beach_brick 155 127 89
+naturalbiomes:med_brick 150 145 129
+naturalbiomes:outback_brick 171 119 83
+
+
+# bambooforest
+
+naturalbiomes:bambooforest_litter 70 94 16
+naturalbiomes:bamboo_trunk 123 126 51
+naturalbiomes:bamboo_leaves 113 145 10
+naturalbiomes:bamboo_sapling 17 19 8
+stairs:slab_naturalbiomes_bambooforest_bamboo_wood2 123 126 51
+stairs:stair_naturalbiomes_bambooforest_bamboo_wood2 123 126 51
+stairs:stair_outer_naturalbiomes_bambooforest_bamboo_wood2 123 126 51
+stairs:stair_inner_naturalbiomes_bambooforest_bamboo_wood2 123 126 51
+stairs:slab_naturalbiomes_bambooforest_bamboo_trunk 98 86 57
+stairs:stair_naturalbiomes_bambooforest_bamboo_trunk 98 86 57
+stairs:stair_outer_naturalbiomes_bambooforest_bamboo_trunk 98 86 57
+stairs:stair_inner_naturalbiomes_bambooforest_bamboo_trunk 98 86 57
+naturalbiomes:gate_bamboo_wood 123 126 51
+naturalbiomes:fence_bamboo_wood 120 123 51
+naturalbiomes:fence_rail_bamboo_wood 120 123 51
+naturalbiomes:smallbamboo 21 23 13
+naturalbiomes:bambooforest_rock 148 106 69
+naturalbiomes:bambooforest_groundgrass 48 65 28
+naturalbiomes:bambooforest_groundgrass2 46 62 27
+naturalbiomes:banana_trunk 108 92 48
+naturalbiomes:banana_leaves 107 145 67
+naturalbiomes:banana_sapling 47 58 17
+stairs:slab_naturalbiomes_banana_wood 108 92 48
+stairs:stair_naturalbiomes_banana_wood 108 92 48
+stairs:stair_outer_naturalbiomes_banana_wood 108 92 48
+stairs:stair_inner_naturalbiomes_banana_wood 108 92 48
+stairs:slab_naturalbiomes_banana_trunk 107 95 35
+stairs:stair_naturalbiomes_banana_trunk 107 95 35
+stairs:stair_outer_naturalbiomes_banana_trunk 107 95 35
+stairs:stair_inner_naturalbiomes_banana_trunk 107 95 35
+naturalbiomes:gate_banana_wood 108 92 48
+naturalbiomes:fence_banana_wood 108 92 48
+naturalbiomes:fence_rail_banana_wood 108 92 48
+
+
+# outback
+
+naturalbiomes:outback_litter 204 112 45
+naturalbiomes:outback_rock 224 146 85
+naturalbiomes:outback_ground 186 103 72
+naturalbiomes:outback_trunk 136 109 88
+naturalbiomes:outback_leaves 111 118 84
+naturalbiomes:outback_sapling 91 96 86
+stairs:slab_naturalbiomes_outback_eukalyptus_wood 136 109 88
+stairs:stair_naturalbiomes_outback_eukalyptus_wood 136 109 88
+stairs:stair_outer_naturalbiomes_outback_eukalyptus_wood 136 109 88
+stairs:stair_inner_naturalbiomes_outback_eukalyptus_wood 136 109 88
+stairs:slab_naturalbiomes_outbackeucalyptus_trunk 181 160 143
+stairs:stair_naturalbiomes_outbackeucalyptus_trunk 181 160 143
+stairs:stair_outer_naturalbiomes_outbackeucalyptus_trunk 181 160 143
+stairs:stair_inner_naturalbiomes_outbackeucalyptus_trunk 181 160 143
+naturalbiomes:gate_outback_wood 136 109 88
+naturalbiomes:fence_outback_wood 136 109 88
+naturalbiomes:fence_rail_outback_wood 136 109 88
+naturalbiomes:outback_bush_stem 63 63 62
+naturalbiomes:outback_bush_leaves 139 127 86
+naturalbiomes:outback_bush_sapling 63 63 62
+naturalbiomes:outback_grass 90 61 18
+naturalbiomes:outback_grass2 46 47 30
+naturalbiomes:outback_grass3 96 68 33
+naturalbiomes:outback_grass4 56 51 16
+naturalbiomes:outback_grass5 97 100 85
+naturalbiomes:outback_grass6 96 53 15
+naturalbiomes:outback_rockformation1 186 150 101
+
+
+# alderswamp
+
+naturalbiomes:alderswamp_litter 135 144 104
+naturalbiomes:alderswamp_dirt 79 70 67
+naturalbiomes:alder_trunk 135 118 81
+naturalbiomes:alder_leaves 91 116 44
+naturalbiomes:alder_sapling 38 43 31
+stairs:slab_naturalbiomes_alderswamp_alder_wood 135 118 81
+stairs:stair_naturalbiomes_alderswamp_alder_wood 135 118 81
+stairs:stair_outer_naturalbiomes_alderswamp_alder_wood 135 118 81
+stairs:stair_inner_naturalbiomes_alderswamp_alder_wood 135 118 81
+stairs:slab_naturalbiomes_alderswamp_alder_trunk 138 125 92
+stairs:stair_naturalbiomes_alderswamp_alder_trunk 138 125 92
+stairs:stair_outer_naturalbiomes_alderswamp_alder_trunk 138 125 92
+stairs:stair_inner_naturalbiomes_alderswamp_alder_trunk 138 125 92
+naturalbiomes:gate_alder_wood 135 118 81
+naturalbiomes:fence_alder_wood 138 121 83
+naturalbiomes:fence_rail_alder_wood 138 121 83
+naturalbiomes:alderswamp_reed 58 73 12
+naturalbiomes:alderswamp_reed 58 73 12
+naturalbiomes:alderswamp_reed2 68 87 13
+naturalbiomes:alderswamp_reed3 80 99 17
+naturalbiomes:waterlily 92 98 56
+naturalbiomes:alderswamp_yellowflower 49 73 17
+naturalbiomes:alderswamp_brownreed 27 32 8
+
+
+# palmbeach
+
+naturalbiomes:palmbeach_sand 222 211 179
+naturalbiomes:palmbeach_rock 186 150 101
+naturalbiomes:palm_trunk 119 81 41
+naturalbiomes:palm_leaves 89 110 44
+naturalbiomes:palm_sapling 72 72 31
+stairs:slab_naturalbiomes_savannapalm_wood 119 81 41
+stairs:stair_naturalbiomes_savannapalm_wood 119 81 41
+stairs:stair_outer_naturalbiomes_savannapalm_wood 119 81 41
+stairs:stair_inner_naturalbiomes_savannapalm_wood 119 81 41
+stairs:slab_naturalbiomes_savannapalm_trunk 84 57 23
+stairs:stair_naturalbiomes_savannapalm_trunk 84 57 23
+stairs:stair_outer_naturalbiomes_savannapalm_trunk 84 57 23
+stairs:stair_inner_naturalbiomes_savannapalm_trunk 84 57 23
+naturalbiomes:gate_palm_wood 119 81 41
+naturalbiomes:fence_palm_wood 120 81 41
+naturalbiomes:fence_rail_palm_wood 120 81 41
+naturalbiomes:beach_bush_stem 56 44 23
+naturalbiomes:beach_bush_leaves 109 124 21
+naturalbiomes:beach_bush_sapling 56 44 23
+naturalbiomes:palmbeach_grass1 61 73 13
+naturalbiomes:palmbeach_grass2 59 72 11
+naturalbiomes:palmbeach_grass3 69 76 30
+naturalbiomes:banana_bunch 57 57 7
+naturalbiomes:banana 43 40 0
+naturalbiomes:coconut_slice 43 35 28
+naturalbiomes:coconut 87 57 32
+
+
+# alpine
+
+naturalbiomes:alpine_litter 110 144 25
+naturalbiomes:alpine_rock 160 169 180
+naturalbiomes:alppine1_trunk 155 118 72
+naturalbiomes:alppine1_leaves 63 78 25
+naturalbiomes:alppine1_sapling 25 29 19
+stairs:slab_naturalbiomes_alpine_pine1_wood 155 118 72
+stairs:stair_naturalbiomes_alpine_pine1_wood 155 118 72
+stairs:stair_outer_naturalbiomes_alpine_pine1_wood 155 118 72
+stairs:stair_inner_naturalbiomes_alpine_pine1_wood 155 118 72
+stairs:slab_naturalbiomes_alpine_pine1_trunk 188 160 118
+stairs:stair_naturalbiomes_alpine_pine1_trunk 188 160 118
+stairs:stair_outer_naturalbiomes_alpine_pine1_trunk 188 160 118
+stairs:stair_inner_naturalbiomes_alpine_pine1_trunk 188 160 118
+naturalbiomes:gate_alppine1_wood 155 118 72
+naturalbiomes:fence_alppine1_wood 162 123 76
+naturalbiomes:fence_rail_alppine1_wood 162 123 76
+naturalbiomes:alppine2_trunk 173 132 87
+naturalbiomes:alppine2_leaves 85 104 36
+naturalbiomes:alppine2_sapling 35 41 13
+stairs:slab_naturalbiomes_alpine_pine2_wood 173 132 87
+stairs:stair_naturalbiomes_alpine_pine2_wood 173 132 87
+stairs:stair_outer_naturalbiomes_alpine_pine2_wood 173 132 87
+stairs:stair_inner_naturalbiomes_alpine_pine2_wood 173 132 87
+stairs:slab_naturalbiomes_alpine_pine2_trunk 153 124 84
+stairs:stair_naturalbiomes_alpine_pine2_trunk 153 124 84
+stairs:stair_outer_naturalbiomes_alpine_pine2_trunk 153 124 84
+stairs:stair_inner_naturalbiomes_alpine_pine2_trunk 153 124 84
+naturalbiomes:gate_alppine2_wood 173 132 87
+naturalbiomes:fence_pine2_wood 177 136 89
+naturalbiomes:fence_rail_pine2_wood 177 136 89
+naturalbiomes:alpine_mushroom 100 80 26
+naturalbiomes:alpine_grass1 50 62 6
+naturalbiomes:alpine_grass2 50 63 6
+naturalbiomes:alpine_grass3 61 76 7
+naturalbiomes:alpine_dandelion 54 65 17
+naturalbiomes:alpine_edelweiss 85 88 76
+
+
+# mediterranean
+
+naturalbiomes:mediterran_litter 150 129 92
+naturalbiomes:mediterran_rock 186 177 154
+naturalbiomes:mediterran_ruin 187 162 136
+naturalbiomes:mediterran_ruin2 158 138 115
+naturalbiomes:olive_trunk 175 133 70
+naturalbiomes:olive_leaves 94 97 71
+naturalbiomes:olive_sapling 39 36 26
+stairs:slab_naturalbiomes_mediterran_olive_wood 175 133 70
+stairs:stair_naturalbiomes_mediterran_olive_wood 175 133 70
+stairs:stair_outer_naturalbiomes_mediterran_olive_wood 175 133 70
+stairs:stair_inner_naturalbiomes_mediterran_olive_wood 175 133 70
+stairs:slab_naturalbiomes_mediterran_olive_trunk 144 116 70
+stairs:stair_naturalbiomes_mediterran_olive_trunk 144 116 70
+stairs:stair_outer_naturalbiomes_mediterran_olive_trunk 144 116 70
+stairs:stair_inner_naturalbiomes_mediterran_olive_trunk 144 116 70
+naturalbiomes:gate_olive_wood 175 133 70
+naturalbiomes:fence_olive_wood 174 131 67
+naturalbiomes:fence_rail_olive_wood 174 131 67
+naturalbiomes:pine_trunk 204 168 107
+naturalbiomes:pine_leaves 79 89 20
+naturalbiomes:pine_sapling 25 25 13
+stairs:slab_naturalbiomes_mediterran_pine_wood 204 168 107
+stairs:stair_naturalbiomes_mediterran_pine_wood 204 168 107
+stairs:stair_outer_naturalbiomes_mediterran_pine_wood 204 168 107
+stairs:stair_inner_naturalbiomes_mediterran_pine_wood 204 168 107
+stairs:slab_naturalbiomes_mediterran_pine_trunk 188 152 106
+stairs:stair_naturalbiomes_mediterran_pine_trunk 188 152 106
+stairs:stair_outer_naturalbiomes_mediterran_pine_trunk 188 152 106
+stairs:stair_inner_naturalbiomes_mediterran_pine_trunk 188 152 106
+naturalbiomes:gate_pine_wood 204 168 107
+naturalbiomes:fence_pine_wood 196 161 102
+naturalbiomes:fence_rail_pine_wood 196 161 102
+naturalbiomes:med_bush_stem 32 25 20
+naturalbiomes:med_bush_leaves 95 107 0
+naturalbiomes:med_bush_sapling 32 25 20
+naturalbiomes:med_flower1 53 57 32
+naturalbiomes:med_flower2 44 45 29
+naturalbiomes:med_flower3 45 43 32
+naturalbiomes:med_grass1 45 45 24
+naturalbiomes:med_grass2 43 43 23
+naturalbiomes:olives 54 51 41
+
+
+# wetsavanna
+
+naturalbiomes:savannalitter 109 112 41
+naturalbiomes:acacia_trunk 94 73 52
+naturalbiomes:acacia_leaves 92 97 60
+naturalbiomes:acacia_sapling 49 50 34
+stairs:slab_naturalbiomes_savannaacacia_wood 94 73 52
+stairs:stair_naturalbiomes_savannaacacia_wood 94 73 52
+stairs:stair_outer_naturalbiomes_savannaacacia_wood 94 73 52
+stairs:stair_inner_naturalbiomes_savannaacacia_wood 94 73 52
+stairs:slab_naturalbiomes_savannaacacia_trunk 81 67 49
+stairs:stair_naturalbiomes_savannaacacia_trunk 81 67 49
+stairs:stair_outer_naturalbiomes_savannaacacia_trunk 81 67 49
+stairs:stair_inner_naturalbiomes_savannaacacia_trunk 81 67 49
+naturalbiomes:gate_acacia_wood 94 73 52
+naturalbiomes:fence_acacia_wood 98 77 54
+naturalbiomes:fence_rail_acacia_wood 98 77 54
+naturalbiomes:savannagrass 51 55 16
+naturalbiomes:savannagrasssmall 51 55 16
+naturalbiomes:savanna_flowergrass 50 48 30
+naturalbiomes:savanna_grass2 49 55 21
+naturalbiomes:savanna_grass3 50 56 23

--- a/public/colors/naturalbiomes.txt
+++ b/public/colors/naturalbiomes.txt
@@ -24,7 +24,8 @@ stairs:slab_naturalbiomes_outback_rock_brick 171 119 83
 stairs:stair_naturalbiomes_outback_rock_brick 171 119 83
 stairs:stair_outer_naturalbiomes_outback_rock_brick 171 119 83
 stairs:stair_inner_naturalbiomes_outback_rock_brick 171 119 83
-naturalbiomes:reed_bundle 150 157 165
+naturalbiomes:reed_bundle 87 70 52
+naturalbiomes:alpine_brick 150 157 165
 naturalbiomes:bamboo_brick 143 106 76
 naturalbiomes:beach_brick 155 127 89
 naturalbiomes:med_brick 150 145 129
@@ -34,7 +35,8 @@ naturalbiomes:outback_brick 171 119 83
 # bambooforest
 
 naturalbiomes:bambooforest_litter 70 94 16
-naturalbiomes:bamboo_trunk 123 126 51
+naturalbiomes:bamboo_trunk 98 86 57
+naturalbiomes:bamboo_wood 123 126 51
 naturalbiomes:bamboo_leaves 113 145 10
 naturalbiomes:bamboo_sapling 17 19 8
 stairs:slab_naturalbiomes_bambooforest_bamboo_wood2 123 126 51
@@ -52,7 +54,8 @@ naturalbiomes:smallbamboo 21 23 13
 naturalbiomes:bambooforest_rock 148 106 69
 naturalbiomes:bambooforest_groundgrass 48 65 28
 naturalbiomes:bambooforest_groundgrass2 46 62 27
-naturalbiomes:banana_trunk 108 92 48
+naturalbiomes:banana_trunk 107 95 35
+naturalbiomes:banana_wood 108 92 48
 naturalbiomes:banana_leaves 107 145 67
 naturalbiomes:banana_sapling 47 58 17
 stairs:slab_naturalbiomes_banana_wood 108 92 48
@@ -73,7 +76,8 @@ naturalbiomes:fence_rail_banana_wood 108 92 48
 naturalbiomes:outback_litter 204 112 45
 naturalbiomes:outback_rock 224 146 85
 naturalbiomes:outback_ground 186 103 72
-naturalbiomes:outback_trunk 136 109 88
+naturalbiomes:outback_trunk 181 160 143
+naturalbiomes:outback_wood 136 109 88
 naturalbiomes:outback_leaves 111 118 84
 naturalbiomes:outback_sapling 91 96 86
 stairs:slab_naturalbiomes_outback_eukalyptus_wood 136 109 88
@@ -103,7 +107,8 @@ naturalbiomes:outback_rockformation1 186 150 101
 
 naturalbiomes:alderswamp_litter 135 144 104
 naturalbiomes:alderswamp_dirt 79 70 67
-naturalbiomes:alder_trunk 135 118 81
+naturalbiomes:alder_trunk 138 125 92
+naturalbiomes:alder_wood 135 118 81
 naturalbiomes:alder_leaves 91 116 44
 naturalbiomes:alder_sapling 38 43 31
 stairs:slab_naturalbiomes_alderswamp_alder_wood 135 118 81
@@ -130,7 +135,8 @@ naturalbiomes:alderswamp_brownreed 27 32 8
 
 naturalbiomes:palmbeach_sand 222 211 179
 naturalbiomes:palmbeach_rock 186 150 101
-naturalbiomes:palm_trunk 119 81 41
+naturalbiomes:palm_trunk 84 57 23
+naturalbiomes:palm_wood 119 81 41
 naturalbiomes:palm_leaves 89 110 44
 naturalbiomes:palm_sapling 72 72 31
 stairs:slab_naturalbiomes_savannapalm_wood 119 81 41
@@ -160,7 +166,8 @@ naturalbiomes:coconut 87 57 32
 
 naturalbiomes:alpine_litter 110 144 25
 naturalbiomes:alpine_rock 160 169 180
-naturalbiomes:alppine1_trunk 155 118 72
+naturalbiomes:alppine1_trunk 188 160 118
+naturalbiomes:alppine1_wood 155 118 72
 naturalbiomes:alppine1_leaves 63 78 25
 naturalbiomes:alppine1_sapling 25 29 19
 stairs:slab_naturalbiomes_alpine_pine1_wood 155 118 72
@@ -174,7 +181,8 @@ stairs:stair_inner_naturalbiomes_alpine_pine1_trunk 188 160 118
 naturalbiomes:gate_alppine1_wood 155 118 72
 naturalbiomes:fence_alppine1_wood 162 123 76
 naturalbiomes:fence_rail_alppine1_wood 162 123 76
-naturalbiomes:alppine2_trunk 173 132 87
+naturalbiomes:alppine2_trunk 153 124 84
+naturalbiomes:alppine2_wood 173 132 87
 naturalbiomes:alppine2_leaves 85 104 36
 naturalbiomes:alppine2_sapling 35 41 13
 stairs:slab_naturalbiomes_alpine_pine2_wood 173 132 87
@@ -202,7 +210,8 @@ naturalbiomes:mediterran_litter 150 129 92
 naturalbiomes:mediterran_rock 186 177 154
 naturalbiomes:mediterran_ruin 187 162 136
 naturalbiomes:mediterran_ruin2 158 138 115
-naturalbiomes:olive_trunk 175 133 70
+naturalbiomes:olive_trunk 144 116 70
+naturalbiomes:olive_wood 175 133 70
 naturalbiomes:olive_leaves 94 97 71
 naturalbiomes:olive_sapling 39 36 26
 stairs:slab_naturalbiomes_mediterran_olive_wood 175 133 70
@@ -216,7 +225,8 @@ stairs:stair_inner_naturalbiomes_mediterran_olive_trunk 144 116 70
 naturalbiomes:gate_olive_wood 175 133 70
 naturalbiomes:fence_olive_wood 174 131 67
 naturalbiomes:fence_rail_olive_wood 174 131 67
-naturalbiomes:pine_trunk 204 168 107
+naturalbiomes:pine_trunk 188 152 106
+naturalbiomes:pine_wood 204 168 107
 naturalbiomes:pine_leaves 79 89 20
 naturalbiomes:pine_sapling 25 25 13
 stairs:slab_naturalbiomes_mediterran_pine_wood 204 168 107
@@ -244,7 +254,8 @@ naturalbiomes:olives 54 51 41
 # wetsavanna
 
 naturalbiomes:savannalitter 109 112 41
-naturalbiomes:acacia_trunk 94 73 52
+naturalbiomes:acacia_trunk 81 67 49
+naturalbiomes:acacia_wood 94 73 52
 naturalbiomes:acacia_leaves 92 97 60
 naturalbiomes:acacia_sapling 49 50 34
 stairs:slab_naturalbiomes_savannaacacia_wood 94 73 52


### PR DESCRIPTION
Adds node/colour support for the [Wilhelmines Natural Biomes](https://content.minetest.net/packages/Liil/naturalbiomes/).

Colours were generated by scraping the Lua files and generating average colours from the node's associated textures. Visual inspection seems to indicate the colours came out accurately. 

![image](https://user-images.githubusercontent.com/6191747/198866475-85d16906-3116-4a8a-a2b4-30e133b0b3b0.png)

![image](https://user-images.githubusercontent.com/6191747/198866408-41ba1d25-4a97-4f63-85f8-fcc4902766c4.png)
