### PR TITLE
feat: added configuration options via Environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM scratch
 COPY mapserver /bin/mapserver
+ENV MT_CONFIG_PATH "/bin/mapserver.json"
+ENV MT_LOGLEVEL "INFO"
+ENV MT_READONLY "false"
 EXPOSE 8080
 ENTRYPOINT ["/bin/mapserver"]


### PR DESCRIPTION
Here are more additions for containers (mostly):

This change adds 3 Environment Variables:
```dockerfile
ENV MT_CONFIG_PATH "/bin/mapserver.json"
ENV MT_LOGLEVEL "INFO"
ENV MT_READONLY "false"
```

MT_CONFIG_PATH allows to specify the exact location for the config.
MT_READONLY has been introduced because i used a k8s configmap for my configuration. Making it Read-Only.