### PR TITLE
Add support for custom colors.txt dir

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -129,6 +129,7 @@ func ParseConfig(filename string) (*Config, error) {
 		Skins:                     &skins,
 		WorldPath:                 "./",
 		DataPath:                  "./",
+		ColorsTxtPath:             "./",
 	}
 
 	info, err := os.Stat(filename)

--- a/app/setup.go
+++ b/app/setup.go
@@ -100,11 +100,11 @@ func Setup(p params.ParamsType, cfg *Config) *App {
 	}
 
 	//load provided colors, if available
-	info, err := os.Stat(filepath.Join(a.Config.DataPath, "colors.txt"))
+	info, err := os.Stat(filepath.Join(a.Config.ColorsTxtPath, "colors.txt"))
 	if info != nil && err == nil {
 		logrus.WithFields(logrus.Fields{"filename": "colors.txt"}).Info("Loading colors from filesystem")
 
-		data, err := os.ReadFile(filepath.Join(a.Config.DataPath, "colors.txt"))
+		data, err := os.ReadFile(filepath.Join(a.Config.ColorsTxtPath, "colors.txt"))
 		if err != nil {
 			panic(err)
 		}

--- a/app/types.go
+++ b/app/types.go
@@ -26,6 +26,7 @@ type Config struct {
 	Skins                     *SkinsConfig            `json:"skins"`
 	WorldPath                 string                  `json:"worldpath"`
 	DataPath                  string                  `json:"datapath"`
+	ColorsTxtPath             string                  `json:colorstxtpath`
 }
 
 type MapBlockAccessorConfig struct {


### PR DESCRIPTION
Usecase: I have an extra repo for the colors.txt file and I don't want to save the mapserver tiles in this dir too. https://github.com/Archtec-io/colorstxt