### PR TITLE
Building Docker images inside Docker containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,14 @@ mapserver.sqlite
 mapserver.sqlite-journal
 mapserver.json
 debug.txt
+
+mapserver
+.github
+dev
+doc
+readme.md
+
+public/js/bundle.js
+public/js/bundle.js.map
+public/js/bundle-stats.js
+public/js/bundle-stats.js.map

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,34 +17,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v5.0.0
-        with:
-          go-version: "1.21"
-
-      - name: Set up nodejs
-        uses: actions/setup-node@v4
-        with:
-          node-version: '17'
-      
-      - name: Create frontend bundle
-        run: cd public && npm ci && npm run bundle
-
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Tests
-        run: |
-          go test ./...
-
       # only on tags or the master branch
       - name: Docker Login
-        if: success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
+        if: (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -60,10 +35,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Run tests
+      - name: Run tests
+        run: |
+          docker build . --progress plain --no-cache --target run-test
+
       # only on the master branch
       - name: Build and push latest docker image
         if: success() && github.ref == 'refs/heads/master'
         run: |
-          CGO_ENABLED=0 go build .
           docker build . -t minetestmapserver/mapserver:latest
           docker push minetestmapserver/mapserver:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
       # only on tags or the master branch
       - name: Docker Login
-        if: (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
+        if: success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,12 @@ WORKDIR /src
 RUN CGO_ENABLED=0 GOOS=linux go build
 
 #== Run the tests
+# Use this command to ensure it runs:
+## docker build . --progress plain --no-cache --target run-test
 FROM build AS run-test
 RUN go test -v ./...
 
 #== Export the image
-# Use this command to ensure it runs:
-## docker build . --progress plain --no-cache --target run-test
 FROM scratch AS release
 
 # Copy the binary and license

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
+#== Define versions here.
+ARG ALPHINE_VER=3.20
+ARG NODE_VER=22.2
+ARG GO_VER=1.22
+
 #== Container for running rolllup. That's all.
-FROM node:22-alpine as rollup
+FROM node:${NODE_VER}-alpine${ALPHINE_VER} as rollup
 
 RUN npm install --global rollup
 
@@ -9,18 +14,27 @@ WORKDIR /src
 WORKDIR /src/public
 RUN rollup -c rollup.config.js
 
-#== The runtime golang container. This is the one to be exported.
-FROM golang:1.22-alpine as runtime
+#== The container building Go codes.
+FROM golang:${GO_VER}-alpine${ALPHINE_VER} AS build
 
 # Get the rolled up files
 COPY --from=rollup /src /src
 WORKDIR /src
 
 # Build the binary
-RUN go build
+RUN CGO_ENABLED=0 GOOS=linux go build
 
-# Keep backward compatibility
-RUN ln -s ../src/mapserver /bin/mapserver
+#== Run the tests
+FROM build AS run-test
+RUN go test -v ./...
+
+#== Export the image
+# Use this command to ensure it runs:
+## docker build . --progress plain --no-cache --target run-test
+FROM alpine:${ALPHINE_VER} AS release
+
+# Copy the binary
+COPY --from=build /src/mapserver /bin/mapserver
 
 # Set up default env variables
 ENV MT_CONFIG_PATH "mapserver.json"
@@ -29,4 +43,4 @@ ENV MT_READONLY "false"
 
 # Final definitions
 EXPOSE 8080
-ENTRYPOINT ["/src/mapserver"]
+ENTRYPOINT ["/bin/mapserver"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ WORKDIR /src
 # Build the binary
 RUN go build
 
+# Keep backward compatibility
+RUN ln -s ../src/mapserver /bin/mapserver
+
 # Set up default env variables
 ENV MT_CONFIG_PATH "mapserver.json"
 ENV MT_LOGLEVEL "INFO"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 #== Define versions here.
 ARG ALPHINE_VER=3.20
 ARG NODE_VER=22.2
-ARG GO_VER=1.22
+ARG GO_VER=1.21
 
-#== Container for running rolllup. That's all.
+#== Container for running rollup. That's all.
 FROM node:${NODE_VER}-alpine${ALPHINE_VER} as rollup
 
 RUN npm install --global rollup
@@ -31,7 +31,7 @@ RUN go test -v ./...
 #== Export the image
 # Use this command to ensure it runs:
 ## docker build . --progress plain --no-cache --target run-test
-FROM alpine:${ALPHINE_VER} AS release
+FROM scratch AS release
 
 # Copy the binary
 COPY --from=build /src/mapserver /bin/mapserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #== Container for running rolllup. That's all.
-FROM node:22-alphine as rollup
+FROM node:22 as rollup
 
 RUN npm install --global rollup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,29 @@
-FROM scratch
-COPY mapserver /bin/mapserver
+#== Container for running rolllup. That's all.
+FROM node:22-alphine as rollup
+
+RUN npm install --global rollup
+
+COPY . /src
+WORKDIR /src
+
+WORKDIR /src/public
+RUN rollup -c rollup.config.js
+
+#== The runtime golang container. This is the one to be exported.
+FROM golang:1.19 as runtime
+
+# Get the rolled up files
+COPY --from=rollup /src /src
+WORKDIR /src
+
+# Build the binary
+RUN go build
+
+# Set up default env variables
 ENV MT_CONFIG_PATH "mapserver.json"
 ENV MT_LOGLEVEL "INFO"
 ENV MT_READONLY "false"
+
+# Final definitions
 EXPOSE 8080
-ENTRYPOINT ["/bin/mapserver"]
+ENTRYPOINT ["/src/mapserver"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #== Container for running rolllup. That's all.
-FROM node:22 as rollup
+FROM node:22-alpine as rollup
 
 RUN npm install --global rollup
 
@@ -10,7 +10,7 @@ WORKDIR /src/public
 RUN rollup -c rollup.config.js
 
 #== The runtime golang container. This is the one to be exported.
-FROM golang:1.19 as runtime
+FROM golang:1.22-alpine as runtime
 
 # Get the rolled up files
 COPY --from=rollup /src /src

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,15 @@
+#== Minimal Dockerfile for goreleaser.
+FROM scratch AS release
+
+# Copy the binary and license
+COPY /mapserver /bin/mapserver
+COPY license.txt license_mapserver.txt
+
+# Set up default env variables
+ENV MT_CONFIG_PATH "mapserver.json"
+ENV MT_LOGLEVEL "INFO"
+ENV MT_READONLY "false"
+
+# Final definitions
+EXPOSE 8080
+ENTRYPOINT ["/bin/mapserver"]

--- a/doc/building.md
+++ b/doc/building.md
@@ -1,7 +1,11 @@
 
 # Building the mapserver
 
-Instructions to build the mapserver from source
+Instructions to build the mapserver from source.
+
+## Docker instructions
+
+Build the image using the provided `Dockerfile`. That's all you have to do. The compiling process will be done inside containers.
 
 ## Build dependencies
 


### PR DESCRIPTION
This PR changes the process of building Docker images. In this version, both `rollup` and `go build` are done in containers. All building containers are Alpine, and the release image is made from scratch. After this change, we can let GitHub do the build for us.

If the compiling is not done in the docker image, the binary may struggle to find proper libraries in the docker image due to incompatibilities.

This PR is tested on [my server](https://map-twi.1f616emo.xyz) ([some additional patches applied](https://github.com/minetest-mapserver/mapserver/compare/master...C-C-Minetest-Server:mapserver:fork-master)).