### PR TITLE
Support ATMs and WTT from Unified Money

### DIFF
--- a/mapobject/atm.go
+++ b/mapobject/atm.go
@@ -14,18 +14,15 @@ func (this *ATM) onMapObject(mbpos *types.MapBlockCoords, x, y, z int, block *ma
 
 	o := mapobjectdb.NewMapObject(mbpos, x, y, z, "atm")
 
-	if nodename == "atm:wtt" {
-		o.Attributes["type"] = "wiretransfer"
-
-	} else if nodename == "atm:atm2" {
-		o.Attributes["type"] = "atm2"
-
-	} else if nodename == "atm:atm3" {
-		o.Attributes["type"] = "atm3"
-
-	} else {
-		o.Attributes["type"] = "atm"
-
+	switch nodename {
+		case "atm:wtt", "um_wtt:wtt":
+			o.Attributes["type"] = "wiretransfer"
+		case "atm:atm2", "um_atm:atm_2":
+			o.Attributes["type"] = "atm2"
+		case "atm:atm3", "um_atm:atm_3":
+			o.Attributes["type"] = "atm3"
+		default:
+			o.Attributes["type"] = "atm"
 	}
 
 	return o

--- a/mapobject/setup.go
+++ b/mapobject/setup.go
@@ -164,10 +164,18 @@ func Setup(ctx *app.App) {
 
 	if ctx.Config.MapObjects.ATM {
 		atm := &ATM{}
+
+		// ATMs and WTT of gpcf's mod
 		l.AddMapObject("atm:atm", atm)
 		l.AddMapObject("atm:atm2", atm)
 		l.AddMapObject("atm:atm3", atm)
 		l.AddMapObject("atm:wtt", atm)
+
+		// ATMs and WTT of Unified Money
+		l.AddMapObject("um_atm:atm_1", atm)
+		l.AddMapObject("um_atm:atm_2", atm)
+		l.AddMapObject("um_atm:atm_3", atm)
+		l.AddMapObject("um_wtt:wtt", atm)
 	}
 
 	//locator


### PR DESCRIPTION
This PR adds [ATMs](https://content.minetest.net/packages/Emojiminetest/um_atm/) and [WTTs](https://content.minetest.net/packages/Emojiminetest/um_wtt/) for [Unified Money](https://content.minetest.net/packages/Emojiminetest/unified_money/) into the map server.

This PR is a work in progress... mainly because no ATMs are showing up on my map yet. The code is running smoothly, so once they appear, this PR can be seen as ready for review.

[This is one of the ATMs on my server](https://map-twi.1f616emo.xyz/#!/map/0/12/-1575/538). Don't forget to enable the ATM layer first - it is not on by default.