### PR TITLE
Put markers at the center of nodes

### DIFF
--- a/public/js/map/overlays/AbstractIconOverlay.js
+++ b/public/js/map/overlays/AbstractIconOverlay.js
@@ -117,7 +117,7 @@ export default L.LayerGroup.extend({
             return;
           }
 
-          marker = L.marker([obj.z, obj.x], {icon: icon});
+          marker = L.marker([obj.z + 0.5, obj.x + 0.5], {icon: icon});
           popup = self.createPopup(obj);
           if (popup)
             marker.bindPopup(popup);

--- a/public/js/map/overlays/AirUtilsPlanesOverlay.js
+++ b/public/js/map/overlays/AirUtilsPlanesOverlay.js
@@ -66,7 +66,7 @@ export default L.LayerGroup.extend({
   },
 
   createMarker: function(plane) {
-    let marker = L.marker([plane.pos.z, plane.pos.x], {icon: this.getIcon(plane)});
+    let marker = L.marker([plane.pos.z + 0.5, plane.pos.x + 0.5], {icon: this.getIcon(plane)});
 
     marker.bindPopup(this.createPopup(plane));
 
@@ -115,7 +115,7 @@ export default L.LayerGroup.extend({
       if (this.currentObjects[plane.id]) {
         //marker exists
         let marker = this.currentObjects[plane.id];
-        marker.setLatLng([plane.pos.z, plane.pos.x]);
+        marker.setLatLng([plane.pos.z + 0.5, plane.pos.x + 0.5]);
         marker.setIcon(this.getIcon(plane));
         marker.setPopupContent(this.createPopup(plane));
       } else {

--- a/public/js/map/overlays/BorderOverlay.js
+++ b/public/js/map/overlays/BorderOverlay.js
@@ -63,13 +63,13 @@ export default AbstractGeoJsonOverlay.extend({
 
       //Add stations
       borders[bordername].forEach(function(entry){
-        coords.push([entry.x, entry.z]);
+        coords.push([entry.x + 0.5, entry.z + 0.5]);
       });
 
       // closing border
       coords.push([
-        borders[bordername][0].x,
-        borders[bordername][0].z
+        borders[bordername][0].x + 0.5,
+        borders[bordername][0].z + 0.5
       ]);
 
       var feature = {

--- a/public/js/map/overlays/MinecartOverlay.js
+++ b/public/js/map/overlays/MinecartOverlay.js
@@ -29,7 +29,7 @@ export default L.LayerGroup.extend({
       popupAnchor:  [0, -32]
     });
 
-    var marker = L.marker([cart.pos.z, cart.pos.x], {icon: Icon});
+    var marker = L.marker([cart.pos.z + 0.5, cart.pos.x + 0.5], {icon: Icon});
     var html = "<b>Minecart</b><hr>";
     html += "<b>Id: </b> " + cart.id + "<br>";
 
@@ -64,7 +64,7 @@ export default L.LayerGroup.extend({
 
       if (self.currentObjects[cart.id]){
         //marker exists
-        self.currentObjects[cart.id].setLatLng([cart.pos.z, cart.pos.x]);
+        self.currentObjects[cart.id].setLatLng([cart.pos.z + 0.5, cart.pos.x + 0.5]);
         //setPopupContent
 
       } else {

--- a/public/js/map/overlays/PlayerOverlay.js
+++ b/public/js/map/overlays/PlayerOverlay.js
@@ -57,7 +57,7 @@ export default L.LayerGroup.extend({
   },
 
   createMarker: function(player) {
-    const marker = L.marker([player.pos.z, player.pos.x], {icon: this.getIcon(player)});
+    const marker = L.marker([player.pos.z + 0.5, player.pos.x + 0.5], {icon: this.getIcon(player)});
 
     marker.bindPopup(this.createPopup(player), {minWidth: 220});
     return marker;
@@ -154,7 +154,7 @@ export default L.LayerGroup.extend({
       if (this.currentObjects[player.name]){
         //marker exists
         const marker = this.currentObjects[player.name];
-        marker.setLatLng([player.pos.z, player.pos.x]);
+        marker.setLatLng([player.pos.z + 0.5, player.pos.x + 0.5]);
         marker.setIcon(this.getIcon(player));
         marker.setPopupContent(this.createPopup(player));
 

--- a/public/js/map/overlays/PrivProtectorOverlay.js
+++ b/public/js/map/overlays/PrivProtectorOverlay.js
@@ -11,11 +11,11 @@ export default AbstractGeoJsonOverlay.extend({
       "geometry": {
         "type":"Polygon",
         "coordinates":[[
-            [protector.x-5,protector.z-5],
-            [protector.x-5,protector.z+6],
-            [protector.x+6,protector.z+6],
-            [protector.x+6,protector.z-5],
-            [protector.x-5,protector.z-5]
+            [protector.x-5 + 0.5,protector.z-5 + 0.5],
+            [protector.x-5 + 0.5,protector.z+6 + 0.5],
+            [protector.x+6 + 0.5,protector.z+6 + 0.5],
+            [protector.x+6 + 0.5,protector.z-5 + 0.5],
+            [protector.x-5 + 0.5,protector.z-5 + 0.5]
         ]]
       },
       "properties":{

--- a/public/js/map/overlays/ProtectorOverlay.js
+++ b/public/js/map/overlays/ProtectorOverlay.js
@@ -15,11 +15,11 @@ export default AbstractGeoJsonOverlay.extend({
       "geometry": {
         "type":"Polygon",
         "coordinates":[[
-            [protector.x-5,protector.z-5],
-            [protector.x-5,protector.z+6],
-            [protector.x+6,protector.z+6],
-            [protector.x+6,protector.z-5],
-            [protector.x-5,protector.z-5]
+            [protector.x-5 + 0.5,protector.z-5 + 0.5],
+            [protector.x-5 + 0.5,protector.z+6 + 0.5],
+            [protector.x+6 + 0.5,protector.z+6 + 0.5],
+            [protector.x+6 + 0.5,protector.z-5 + 0.5],
+            [protector.x-5 + 0.5,protector.z-5 + 0.5]
         ]]
       },
       "properties":{

--- a/public/js/map/overlays/TrainOverlay.js
+++ b/public/js/map/overlays/TrainOverlay.js
@@ -96,7 +96,7 @@ export default L.LayerGroup.extend({
       popupAnchor:  [0, -16]
     });
 
-    var marker = L.marker([train.pos.z, train.pos.x], {icon: Icon});
+    var marker = L.marker([train.pos.z + 0.5, train.pos.x + 0.5], {icon: Icon});
     marker.bindPopup(this.createPopup(train));
 
     return marker;
@@ -134,7 +134,7 @@ export default L.LayerGroup.extend({
       if (this.currentObjects[train.id]){
         //marker exists
         let marker = this.currentObjects[train.id];
-        marker.setLatLng([train.pos.z, train.pos.x]);
+        marker.setLatLng([train.pos.z + 0.5, train.pos.x + 0.5]);
         marker.setPopupContent(this.createPopup(train));
 
       } else {

--- a/public/js/map/overlays/TrainlineOverlay.js
+++ b/public/js/map/overlays/TrainlineOverlay.js
@@ -115,13 +115,13 @@ export default AbstractGeoJsonOverlay.extend({
                 if (pos == null) {
                   console.warn("[Trainlines][linepath_from_prv]", "line "+linename, "block "+pos_to_string(entry), "index "+entry.attributes.index, "Invalid point:", p);
                 } else {
-                  feat.coords.push([pos.x, pos.z]);
+                  feat.coords.push([pos.x + 0.5, pos.z + 0.5]);
                 }
               });
             } else if (rail_pos) {
-              feat.coords.push([rail_pos.x, rail_pos.z]);
+              feat.coords.push([rail_pos.x + 0.5, rail_pos.z + 0.5]);
             } else {
-              feat.coords.push([entry.x, entry.z]);
+              feat.coords.push([entry.x + 0.5, entry.z + 0.5]);
             }
 
             if (entry.attributes.station) {

--- a/public/js/map/overlays/TrainsignalOverlay.js
+++ b/public/js/map/overlays/TrainsignalOverlay.js
@@ -50,7 +50,7 @@ export default L.LayerGroup.extend({
   createMarker: function(signal){
 
     var Icon = signal.green ? IconOn : IconOff;
-    var marker = L.marker([signal.pos.z, signal.pos.x], {icon: Icon});
+    var marker = L.marker([signal.pos.z + 0.5, signal.pos.x + 0.5], {icon: Icon});
     marker.bindPopup(this.createPopup(signal));
 
     return marker;
@@ -89,7 +89,7 @@ export default L.LayerGroup.extend({
       if (this.currentObjects[signalId]){
         //marker exists
         let marker = this.currentObjects[signalId];
-        marker.setLatLng([signal.pos.z, signal.pos.x]);
+        marker.setLatLng([signal.pos.z + 0.5, signal.pos.x + 0.5]);
         marker.setPopupContent(this.createPopup(signal));
         marker.setIcon(signal.green ? IconOn : IconOff);
 

--- a/public/js/map/overlays/XPProtectorOverlay.js
+++ b/public/js/map/overlays/XPProtectorOverlay.js
@@ -11,11 +11,11 @@ export default AbstractGeoJsonOverlay.extend({
       "geometry": {
         "type":"Polygon",
         "coordinates":[[
-            [protector.x-5,protector.z-5],
-            [protector.x-5,protector.z+6],
-            [protector.x+6,protector.z+6],
-            [protector.x+6,protector.z-5],
-            [protector.x-5,protector.z-5]
+            [protector.x-5 + 0.5,protector.z-5 + 0.5],
+            [protector.x-5 + 0.5,protector.z+6 + 0.5],
+            [protector.x+6 + 0.5,protector.z+6 + 0.5],
+            [protector.x+6 + 0.5,protector.z-5 + 0.5],
+            [protector.x-5 + 0.5,protector.z-5 + 0.5]
         ]]
       },
       "properties":{


### PR DESCRIPTION
This PR centers markers. Previously, they are placed in the lower left corner. 

| Before | After |
|:---:|:---:|
| ![Before](https://github.com/minetest-mapserver/mapserver/assets/55009343/78a10166-9c9d-448c-8b75-b22474b2ed56) | ![After](https://github.com/minetest-mapserver/mapserver/assets/55009343/5e06c0b4-8fdf-4954-a78d-abfaaf2d89eb) |
| ![Before](https://github.com/minetest-mapserver/mapserver/assets/55009343/8ffb0a04-8956-4a4b-9852-7e8ab3df7bd2) | ![After](https://github.com/minetest-mapserver/mapserver/assets/55009343/483fcce5-38f0-4ea9-891a-e86f4f6bf504) |



This PR is ready for review.

