### PR TITLE
Prevent POI image from vertically overflowing too much

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -49,6 +49,12 @@ body {
   grid-area: info;
 }
 
+.poi_image_container {
+  width: 100%;
+  max-height: 75vh;
+  overflow-y: auto;
+}
+
 .poi_image {
   width: 100%;
   height: auto;

--- a/public/js/map/overlays/PoiOverlay.js
+++ b/public/js/map/overlays/PoiOverlay.js
@@ -30,8 +30,9 @@ export default AbstractIconOverlay.extend({
     }
 
     if (poi.attributes.image) {
-      innerHTML += "<img class=\"poi_image\" src=\"" + HtmlSanitizer.SanitizeHtml(poi.attributes.image) +
-        "\" crossorigin=\"anonymous\" referrerpolicy=\"origin-when-cross-origin\">";
+      innerHTML += "<div class=\"poi_image_container\">" +
+        "<img class=\"poi_image\" src=\"" + HtmlSanitizer.SanitizeHtml(poi.attributes.image) +
+        "\" crossorigin=\"anonymous\" referrerpolicy=\"origin-when-cross-origin\"></div>";
     }
 
     innerHTML += "<hr><b>Owner: </b> " + HtmlSanitizer.SanitizeHtml(poi.attributes.owner) + "<br>";


### PR DESCRIPTION
This PR fixes an issue in #389. Previously, POI owners could set a tall image that overflows the screen. The modified code limits the height to 75% of the viewpoint height and allows scrolling down to see the remaining parts.

This PR is ready for review.

![圖片](https://github.com/minetest-mapserver/mapserver/assets/55009343/e6e394ab-fdb1-4234-930e-e26082e8de9c)
