### PR TITLE
Show layer selector only if more that one layer

### DIFF
--- a/public/js/components/LayerSelector.js
+++ b/public/js/components/LayerSelector.js
@@ -7,9 +7,11 @@ function onchange(e){
   m.route.set("/map/:layerId/:zoom/:lon/:lat", params);
 }
 
-
 export default {
   view: function(){
+    // Display layer selector only if there is choice
+    if (LayerManager.layers.length <= 1)
+      return null;
 
     const layers = LayerManager.layers.map(layer => m(
       "option",


### PR DESCRIPTION
Hide layer selector if only one layer exists.

Cherry-picked from https://github.com/EvidenceBKidscode/mapserver/commit/9d256446eca457fe53ca81fe60ba06980454943e

Tested on https://map.luanti.ru