### PR TITLE
tweak trains and trainlines displayed zoom

### DIFF
--- a/public/js/map/overlays/TrainOverlay.js
+++ b/public/js/map/overlays/TrainOverlay.js
@@ -71,7 +71,7 @@ export default L.LayerGroup.extend({
 
 
   getMaxDisplayedZoom: function(){
-    return 10;
+    return 7;
   },
 
   createMarker: function(train){

--- a/public/js/map/overlays/TrainlineOverlay.js
+++ b/public/js/map/overlays/TrainlineOverlay.js
@@ -58,6 +58,10 @@ export default AbstractGeoJsonOverlay.extend({
       }
     });
   },
+
+  getMaxDisplayedZoom: function(){
+    return 4;
+  },
   
   createGeoJson: function(objects){
     var self = this;


### PR DESCRIPTION
Trainlines covers large distances. Therefore, it would be useful to display it at a lower zoom value.

Tested on https://map.luanti.ru