### PR TITLE
signs: interpret newlines as html br tags

### DIFF
--- a/public/js/map/overlays/SignOverlay.js
+++ b/public/js/map/overlays/SignOverlay.js
@@ -28,6 +28,6 @@ export default AbstractIconOverlay.extend({
   },
 
   createPopup: function(sign) {
-    return sign.attributes.display_text;
+    return sign.attributes.display_text.replaceAll("\n","<br/>");
   }
 });


### PR DESCRIPTION
The way Mineclonia stores the built-in sign display_text with up to 4 lines of text is with "\n" between each line when the user has explicitly started a new line. This can be interpreted as "<br/>" in html to more closely match the text that is displayed in-game.