### PR TITLE
fix #450, add pagename to config

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -128,6 +128,7 @@ func ParseConfig(filename string) (*Config, error) {
 		MapObjects:                &mapobjs,
 		MapBlockAccessorCfg:       &mapblockaccessor,
 		DefaultOverlays:           defaultoverlays,
+		PageName:                  "Minetest Mapserver",
 		Skins:                     &skins,
 		WorldPath:                 "./",
 		DataPath:                  "./",

--- a/app/types.go
+++ b/app/types.go
@@ -21,6 +21,7 @@ type Config struct {
 	MapObjects                *MapObjectConfig        `json:"mapobjects"`
 	MapBlockAccessorCfg       *MapBlockAccessorConfig `json:"mapblockaccessor"`
 	DefaultOverlays           []string                `json:"defaultoverlays"`
+	PageName                  string                  `json:"pagename"`
 	Skins                     *SkinsConfig            `json:"skins"`
 	WorldPath                 string                  `json:"worldpath"`
 	DataPath                  string                  `json:"datapath"`

--- a/dev/mapserver.json
+++ b/dev/mapserver.json
@@ -74,6 +74,7 @@
 		"mapserver_label",
 		"mapserver_player"
 	],
+	"pagename": "Minetest Mapserver",
 	"skins": {
 		"enableskinsdb": false,
 		"skinspath": ""

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -8,6 +8,7 @@
 * Hide travelnets and missions by pattern "(P)"
 * Added benchmark
 * Minor speed improvements
+* Configurable page name
 
 ## 3.0.0
 

--- a/public/js/map/MapFactory.js
+++ b/public/js/map/MapFactory.js
@@ -15,6 +15,10 @@ export function createMap(node, layerId, zoom, lat, lon){
 
   const cfg = config.get();
 
+  if (cfg.pagename) {
+    document.title = cfg.pagename;
+  }
+
   const map = L.map(node, {
     minZoom: 2,
     maxZoom: 12,

--- a/web/config.go
+++ b/web/config.go
@@ -13,6 +13,7 @@ type PublicConfig struct {
 	Layers          []*types.Layer       `json:"layers"`
 	MapObjects      *app.MapObjectConfig `json:"mapobjects"`
 	DefaultOverlays []string             `json:"defaultoverlays"`
+	PageName        string               `json:"pagename"`
 	EnableSearch    bool                 `json:"enablesearch"`
 }
 
@@ -24,6 +25,7 @@ func (api *Api) GetConfig(resp http.ResponseWriter, req *http.Request) {
 	webcfg.MapObjects = api.Context.Config.MapObjects
 	webcfg.Version = app.Version
 	webcfg.DefaultOverlays = api.Context.Config.DefaultOverlays
+	webcfg.PageName = api.Context.Config.PageName
 	webcfg.EnableSearch = api.Context.Config.EnableSearch
 
 	json.NewEncoder(resp).Encode(webcfg)


### PR DESCRIPTION
This lets a server admin set `pagename` in `mapserver.json` to set the page title.