### PR TITLE
Option to restrict webserver to localhost

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -112,6 +112,7 @@ func ParseConfig(filename string) (*Config, error) {
 	cfg := Config{
 		ConfigVersion:             1,
 		Port:                      8080,
+		LocalhostOnly:             false,
 		EnableRendering:           true,
 		EnablePrometheus:          true,
 		EnableSearch:              true,

--- a/app/types.go
+++ b/app/types.go
@@ -5,6 +5,7 @@ import "mapserver/types"
 type Config struct {
 	ConfigVersion             int                     `json:"configversion"`
 	Port                      int                     `json:"port"`
+	LocalhostOnly             bool                    `json:"localhostonly"`
 	EnablePrometheus          bool                    `json:"enableprometheus"`
 	EnableRendering           bool                    `json:"enablerendering"`
 	EnableSearch              bool                    `json:"enablesearch"`

--- a/dev/mapserver.json
+++ b/dev/mapserver.json
@@ -1,6 +1,7 @@
 {
 	"configversion": 1,
 	"port": 8080,
+	"localhostonly": false,
 	"enableprometheus": true,
 	"enablerendering": true,
 	"enablesearch": true,

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,6 +9,7 @@
 * Added benchmark
 * Minor speed improvements
 * Configurable page name
+* Option to restrict webserver to localhost
 
 ## 3.0.0
 

--- a/web/serve.go
+++ b/web/serve.go
@@ -16,6 +16,7 @@ func Serve(ctx *app.App) {
 	fields := logrus.Fields{
 		"port":   ctx.Config.Port,
 		"webdev": ctx.Config.Webdev,
+		"localhostonly": ctx.Config.LocalhostOnly,
 	}
 	logrus.WithFields(fields).Info("Starting http server")
 
@@ -68,9 +69,14 @@ func Serve(ctx *app.App) {
 		mux.HandleFunc("/api/mapblock/", api.GetMapBlockData)
 	}
 
+	var bind_addr string = ":"+strconv.Itoa(ctx.Config.Port)
+	if ctx.Config.LocalhostOnly {
+		bind_addr = "127.0.0.1:"+strconv.Itoa(ctx.Config.Port)
+	}
+
 	// main entry point
 	http.HandleFunc("/", mux.ServeHTTP)
-	err := http.ListenAndServe(":"+strconv.Itoa(ctx.Config.Port), nil)
+	err := http.ListenAndServe(bind_addr, nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This should fix #418 

- Adds a `localhostonly` option to the config
- Ability to choose between listening on all interfaces or 127.0.0.1 (v4 only for now)
- Default is preserved for backward compatibility (listen on all interfaces)

Code is untested for now. So please have a look at the changes.

I chose this boolean option (all/localhost) to avoid the need of validating the config input as a correct ipv4/v6 address or empty string(->all interfaces). This might lead to more complexity and maybe dependencies which I like to avoid.